### PR TITLE
Prevent double callback in _executeRequest

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -158,8 +158,14 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
     });
   });
   request.on('error', function(e) {
-    callbackCalled= true;
-    callback(e);
+    // from https://github.com/ciaranj/node-oauth/pull/363/files
+    // `www.googleapis.com` does `ECONNRESET` just after data is received in `passBackControl`
+    // this prevents the callback from being called twice, first in passBackControl and second time in here
+    // see also NodeJS Stream documentation: "The 'error' event may be emitted by a Readable implementation at any time"
+    if(!callbackCalled) {
+      callbackCalled= true;
+      callback(e);
+    }
   });
 
   if( (options.method == 'POST' || options.method == 'PUT') && post_body ) {


### PR DESCRIPTION
https://github.com/jaredhanson/passport-google-oauth2/issues/87
https://github.com/ciaranj/node-oauth/pull/363
https://app.asana.com/0/1201901823840878/1202355951513540/f
We think this manifests as https://sentry.io/organizations/replit-kq/issues/3193945711/?project=6318946&query=is%3Aunresolved+oauth%3Atrue&statsPeriod=14d in Sentry